### PR TITLE
ResultSet interface to simplify mocking and testing

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -42,16 +42,14 @@ func (db *Db) Keyspace(keyspace string) (*gocql.KeyspaceMetadata, error) {
 
 // Keyspaces Retrieves all the keyspace names
 func (db *Db) Keyspaces() ([]string, error) {
-	iter := db.session.ExecuteIter("SELECT keyspace_name FROM system_schema.keyspaces", nil)
+	iter, err := db.session.ExecuteIter("SELECT keyspace_name FROM system_schema.keyspaces", nil)
+	if err != nil {
+		return nil, err
+	}
 
 	var keyspaces []string
-
-	var name string
-	for iter.Scan(&name) {
-		keyspaces = append(keyspaces, name)
-	}
-	if err := iter.Close(); err != nil {
-		return nil, err
+	for _, row := range iter.Values() {
+		keyspaces = append(keyspaces, *row["keyspace_name"].(*string))
 	}
 
 	return keyspaces, nil


### PR DESCRIPTION
Replaced `ResultIterator` with `ResultSet` and separated the result from the error. This simplifies mocking and testing, specially when thinking about testing resolver behavior.

Also, naming conventions is factored out of the package `db`. As a downside, the row is first created as a map using the column name, that later is adapted as a different map based on the field name (`strcase.ToLowerCamel()` for now), but I think the performance impact should be negligible.