### PR TITLE
Parse LWT result

### DIFF
--- a/db/query_generators.go
+++ b/db/query_generators.go
@@ -72,7 +72,7 @@ func (db *Db) Select(info *SelectInfo, options *QueryOptions) (ResultSet, error)
 	return db.session.ExecuteIter(query, options, values...)
 }
 
-func (db *Db) Insert(info *InsertInfo, options *QueryOptions) (*types.ModificationResult, error) {
+func (db *Db) Insert(info *InsertInfo, options *QueryOptions) (ResultSet, error) {
 
 	placeholders := "?"
 	for i := 1; i < len(info.Columns); i++ {
@@ -92,12 +92,10 @@ func (db *Db) Insert(info *InsertInfo, options *QueryOptions) (*types.Modificati
 		info.QueryParams = append(info.QueryParams, info.TTL)
 	}
 
-	err := db.session.Execute(query, options, info.QueryParams...)
-
-	return &types.ModificationResult{Applied: err == nil}, err
+	return db.session.ExecuteIter(query, options, info.QueryParams...)
 }
 
-func (db *Db) Delete(info *DeleteInfo, options *QueryOptions) (*types.ModificationResult, error) {
+func (db *Db) Delete(info *DeleteInfo, options *QueryOptions) (ResultSet, error) {
 	whereClause := buildWhereClause(info.Columns)
 	query := fmt.Sprintf("DELETE FROM %s.%s WHERE %s", info.Keyspace, info.Table, whereClause)
 	queryParameters := make([]interface{}, len(info.QueryParams))
@@ -109,11 +107,10 @@ func (db *Db) Delete(info *DeleteInfo, options *QueryOptions) (*types.Modificati
 		query += " IF " + buildCondition(info.IfCondition, &queryParameters)
 	}
 
-	err := db.session.Execute(query, options, queryParameters...)
-	return &types.ModificationResult{Applied: err == nil}, err
+	return db.session.ExecuteIter(query, options, queryParameters...)
 }
 
-func (db *Db) Update(info *UpdateInfo, options *QueryOptions) (*types.ModificationResult, error) {
+func (db *Db) Update(info *UpdateInfo, options *QueryOptions) (ResultSet, error) {
 	// We have to differentiate between WHERE and SET clauses
 	setClause := ""
 	whereClause := ""
@@ -173,8 +170,7 @@ func (db *Db) Update(info *UpdateInfo, options *QueryOptions) (*types.Modificati
 		query += " IF " + buildCondition(info.IfCondition, &queryParameters)
 	}
 
-	err := db.session.Execute(query, options, queryParameters...)
-	return &types.ModificationResult{Applied: err == nil}, err
+	return db.session.ExecuteIter(query, options, queryParameters...)
 }
 
 func buildWhereClause(columnNames []string) string {

--- a/db/query_generators_test.go
+++ b/db/query_generators_test.go
@@ -28,7 +28,7 @@ func TestDeleteGeneration(t *testing.T) {
 			session: &sessionMock,
 		}
 
-		sessionMock.On("Execute", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		sessionMock.On("ExecuteIter", mock.Anything, mock.Anything, mock.Anything).Return(ResultMock{}, nil)
 
 		_, err := db.Delete(&DeleteInfo{
 			Keyspace:    "ks1",
@@ -48,7 +48,7 @@ func TestDeleteGeneration(t *testing.T) {
 				expectedQueryParams = append(expectedQueryParams, condition.Value)
 			}
 		}
-		sessionMock.AssertCalled(t, "Execute", item.query, mock.Anything, expectedQueryParams)
+		sessionMock.AssertCalled(t, "ExecuteIter", item.query, mock.Anything, expectedQueryParams)
 		sessionMock.AssertExpectations(t)
 	}
 }
@@ -86,7 +86,7 @@ func TestUpdateGeneration(t *testing.T) {
 			session: &sessionMock,
 		}
 
-		sessionMock.On("Execute", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		sessionMock.On("ExecuteIter", mock.Anything, mock.Anything, mock.Anything).Return(ResultMock{}, nil)
 
 		_, err := db.Update(&UpdateInfo{
 			Keyspace:    "ks1",
@@ -99,7 +99,7 @@ func TestUpdateGeneration(t *testing.T) {
 		}, nil)
 		assert.Nil(t, err)
 
-		sessionMock.AssertCalled(t, "Execute", item.query, mock.Anything, item.expectedParams)
+		sessionMock.AssertCalled(t, "ExecuteIter", item.query, mock.Anything, item.expectedParams)
 		sessionMock.AssertExpectations(t)
 	}
 }
@@ -125,7 +125,7 @@ func TestInsertGeneration(t *testing.T) {
 			session: &sessionMock,
 		}
 
-		sessionMock.On("Execute", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		sessionMock.On("ExecuteIter", mock.Anything, mock.Anything, mock.Anything).Return(ResultMock{}, nil)
 
 		expectedQueryParams := make([]interface{}, len(item.queryParams))
 		copy(expectedQueryParams, item.queryParams)
@@ -143,7 +143,7 @@ func TestInsertGeneration(t *testing.T) {
 			IfNotExists: item.ifNotExists,
 		}, nil)
 		assert.Nil(t, err)
-		sessionMock.AssertCalled(t, "Execute", item.query, mock.Anything, expectedQueryParams)
+		sessionMock.AssertCalled(t, "ExecuteIter", item.query, mock.Anything, expectedQueryParams)
 		sessionMock.AssertExpectations(t)
 	}
 }

--- a/db/session.go
+++ b/db/session.go
@@ -108,6 +108,12 @@ func (session *GoCqlSession) Execute(query string, options *QueryOptions, values
 
 func (session *GoCqlSession) ExecuteIter(query string, options *QueryOptions, values ...interface{}) (ResultSet, error) {
 	q := session.ref.Query(query, values...)
+
+	// Avoid reusing metadata from the prepared statement
+	// Otherwise, we will not get the [applied] column (https://github.com/gocql/gocql/issues/612)
+	// Or new columns for SELECT *
+	q.NoSkipMetadata()
+
 	if options != nil {
 		q.Consistency(options.Consistency)
 


### PR DESCRIPTION
Include the result for conditional mutations, that way the user can obtain the value of the columns that prevented the mutation to occur.

```graphql
mutation {
  insertTblX(data: $data, ifNotExists: true) {
    applied, 
    value {
      id,
      col1,
      col2
    }
  }
}
```

Fixes #17.