### PR TITLE
Remove `serialConsistency` from queries

### DIFF
--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -96,8 +96,7 @@ func TestDataEndpoint_Auth(t *testing.T) {
 				NewQueryOptions().
 				WithUserOrRole("user1").
 				WithPageState([]byte{}).
-				WithConsistency(gocql.LocalQuorum).
-				WithSerialConsistency(gocql.Serial),
+				WithConsistency(gocql.LocalQuorum),
 			mock.Anything).
 		Return(resultMock, nil)
 
@@ -154,8 +153,7 @@ func TestDataEndpoint_AuthNotProvided(t *testing.T) {
 			db.
 				NewQueryOptions().
 				WithUserOrRole("user1").
-				WithConsistency(gocql.LocalQuorum).
-				WithSerialConsistency(gocql.Serial),
+				WithConsistency(gocql.LocalQuorum),
 			mock.Anything).
 		Return(resultMock, errors.New("invalid cre"))
 

--- a/graphql/keyspace_schema.go
+++ b/graphql/keyspace_schema.go
@@ -37,8 +37,7 @@ var inputQueryOptions = graphql.NewInputObject(graphql.InputObjectConfig{
 		"limit":             {Type: graphql.Int},
 		"pageSize":          {Type: graphql.Int},
 		"pageState":         {Type: graphql.String},
-		"consistency":       {Type: consistencyEnum, DefaultValue: gocql.LocalQuorum},
-		"serialConsistency": {Type: consistencyEnum, DefaultValue: gocql.Serial},
+		"consistency":       {Type: queryConsistencyEnum, DefaultValue: gocql.LocalQuorum},
 	},
 })
 
@@ -46,8 +45,8 @@ var inputMutationOptions = graphql.NewInputObject(graphql.InputObjectConfig{
 	Name: "UpdateOptions",
 	Fields: graphql.InputObjectConfigFieldMap{
 		"ttl":               {Type: graphql.Int, DefaultValue: -1},
-		"consistency":       {Type: consistencyEnum, DefaultValue: gocql.LocalQuorum},
-		"serialConsistency": {Type: consistencyEnum, DefaultValue: gocql.Serial},
+		"consistency":       {Type: mutationConsistencyEnum, DefaultValue: gocql.LocalQuorum},
+		"serialConsistency": {Type: serialConsistencyEnum, DefaultValue: gocql.Serial},
 	},
 })
 
@@ -62,12 +61,29 @@ var inputMutationOptionsDefault = types.MutationOptions{
 	SerialConsistency: int(gocql.Serial),
 }
 
-var consistencyEnum = graphql.NewEnum(graphql.EnumConfig{
-	Name: "Consistency",
+var queryConsistencyEnum = graphql.NewEnum(graphql.EnumConfig{
+	Name: "QueryConsistency",
 	Values: graphql.EnumValueConfigMap{
 		"LOCAL_ONE":    {Value: gocql.LocalOne},
 		"LOCAL_QUORUM": {Value: gocql.LocalQuorum},
 		"ALL":          {Value: gocql.All},
+		"SERIAL":       {Value: gocql.Serial},
+		"LOCAL_SERIAL": {Value: gocql.LocalSerial},
+	},
+})
+
+var mutationConsistencyEnum = graphql.NewEnum(graphql.EnumConfig{
+	Name: "MutationConsistency",
+	Values: graphql.EnumValueConfigMap{
+		"LOCAL_ONE":    {Value: gocql.LocalOne},
+		"LOCAL_QUORUM": {Value: gocql.LocalQuorum},
+		"ALL":          {Value: gocql.All},
+	},
+})
+
+var serialConsistencyEnum = graphql.NewEnum(graphql.EnumConfig{
+	Name: "SerialConsistency",
+	Values: graphql.EnumValueConfigMap{
 		"SERIAL":       {Value: gocql.Serial},
 		"LOCAL_SERIAL": {Value: gocql.LocalSerial},
 	},

--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -84,8 +84,7 @@ func (sg *SchemaGenerator) queryFieldResolver(
 				WithUserOrRole(userOrRole).
 				WithPageSize(options.PageSize).
 				WithPageState(pageState).
-				WithConsistency(gocql.Consistency(options.Consistency)).
-				WithSerialConsistency(gocql.SerialConsistency(options.SerialConsistency)))
+				WithConsistency(gocql.Consistency(options.Consistency)))
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
`SERIAL` and `LOCAL` serial are passed through the normal `consistency` field for queries.

Fixes: https://github.com/datastax/cassandra-data-apis/issues/74