### PR TITLE
Integration tests for RoutesGraphQL() with multiple keyspaces

### DIFF
--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -243,7 +243,7 @@ func executePost(routes []graphql.Route, target string, body graphql.RequestBody
 		return nil, err
 	}
 
-	r := httptest.NewRequest(http.MethodPost, path.Join(fmt.Sprintf("http://%s", host), target), bytes.NewReader(b))
+	r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://%s", path.Join(host, target)), bytes.NewReader(b))
 	if header != nil {
 		r.Header = header
 	}


### PR DESCRIPTION
Test routes handled when using `RoutesGraphQL()` method.

Note: `path.Join("http://abc", "other")` was returning `"http:/abc/other`, as path.Join removes excessive path slashes :)